### PR TITLE
fixed circular require and non initialised variable warnings

### DIFF
--- a/lib/dnc.rb
+++ b/lib/dnc.rb
@@ -1,5 +1,3 @@
 require 'dnc/version'
 require 'dnc/dn'
 require 'dnc/string'
-require 'blank'
-require 'array'

--- a/lib/dnc/dn.rb
+++ b/lib/dnc/dn.rb
@@ -1,4 +1,6 @@
 require 'logging'
+require 'blank'
+require 'array'
 
 # Custom exception for strings that can't be parsed as per RFC1779
 class DnDelimiterUnparsableError < TypeError; end
@@ -35,9 +37,7 @@ class DN
 
   # logger method to return Rails logger if defined, else logging logger
   def logger
-    return @logger if @logger
-    logger = Logging.logger[self]
-    @logger ||= Kernel.const_defined?('Rails') ? Rails.logger : logger
+    @logger ||= Kernel.const_defined?('Rails') ? Rails.logger : Logging.logger[self]
   end
 
   # Convert DN object into a string (order follows RFC4514 LDAP specifications)

--- a/lib/dnc/dn.rb
+++ b/lib/dnc/dn.rb
@@ -37,7 +37,11 @@ class DN
 
   # logger method to return Rails logger if defined, else logging logger
   def logger
-    @logger ||= Kernel.const_defined?('Rails') ? Rails.logger : Logging.logger[self]
+    unless defined? @logger
+      logger = Logging.logger[self]
+      @logger = Kernel.const_defined?('Rails') ? Rails.logger : logger
+    end
+    @logger
   end
 
   # Convert DN object into a string (order follows RFC4514 LDAP specifications)

--- a/lib/dnc/string.rb
+++ b/lib/dnc/string.rb
@@ -1,4 +1,4 @@
-require 'dnc'
+require 'dnc/dn'
 
 #
 # Extend the core String class to include `.to_dn` && `.to_dn!`


### PR DESCRIPTION
I've been doing some work using DNC and usually turn on warnings. The current version of DNC has two types of warnings, one is a circular require and the other is non initialised variables. Though neither of these are an actual issue it's good to be able to use warnings without known ones cluttering up the results.

```
rubygems/core_ext/kernel_require.rb:55: warning: loading in progress, circular require considered harmful
dnc/lib/dnc/dn.rb:38: warning: instance variable @logger not initialized
```

The non initialised variable is easily fixed by removing the extra initial test, which is a little cleaner as well.
The circular require is removed, files are required only where they are needed.
