### PR TITLE
Fix assumed upcase

### DIFF
--- a/dnc.gemspec
+++ b/dnc.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '>= 1.9.3'
-  spec.add_dependency 'logging', '~> 1.8'
+  spec.add_dependency 'logging', '>= 1.8', '< 3.0'
 
   spec.add_development_dependency 'awesome_print', '~> 1.2'
   spec.add_development_dependency 'bundler', '~> 1.6'

--- a/dnc.gemspec
+++ b/dnc.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack', '~> 1.5'
   spec.add_development_dependency 'rack-test', '~> 0.6'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rubocop', '~> 0.27'
+  spec.add_development_dependency 'rubocop', '= 0.41.2'
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'yard', '~> 0.8'
 

--- a/lib/dnc/dn.rb
+++ b/lib/dnc/dn.rb
@@ -129,13 +129,7 @@ class DN
 
   # Verify DN starts with 'CN='
   def dn_begins_properly?(dn_str)
-    if dn_str.nil?
-      false
-    else
-      with_delim = "#{delimiter}/CN=".send(@transformation.to_sym)
-      without_delim = 'CN='.send(@transformation.to_sym)
-      dn_str.start_with?(without_delim, with_delim)
-    end
+    dn_str.nil? ? false : /^#{Regexp.escape(delimiter)}?CN/i.match(dn_str)
   end
 
   # Regex to match the DN delimiter by getting the 2nd key non-word predecessor

--- a/lib/dnc/dn.rb
+++ b/lib/dnc/dn.rb
@@ -179,7 +179,7 @@ class DN
     value = send(getter_method.to_sym)
     value.each do |el|
       tmp_str += ',' unless tmp_str.empty?
-      tmp_str += "#{getter_method.to_s.send(@transformation.to_sym)}=#{el}"
+      tmp_str += "#{getter_method.to_s.upcase}=#{el}"
     end
 
     tmp_str
@@ -191,7 +191,7 @@ class DN
     value = send(getter_method.to_sym)
     value.each do |key, string|
       return_string += '+' unless return_string.empty?
-      return_string += "#{key}=#{string}"
+      return_string += "#{key.upcase}=#{string}"
     end
 
     return_string

--- a/lib/dnc/dn.rb
+++ b/lib/dnc/dn.rb
@@ -54,7 +54,7 @@ class DN
       end
     end
 
-    return_string.send(@transformation.to_sym)
+    return_string
   end
 
   # Split passed DN by identified delimiter

--- a/spec/lib/dn_spec.rb
+++ b/spec/lib/dn_spec.rb
@@ -84,5 +84,10 @@ describe DN do
         expect(DN.new(dn_string: dn_in).to_s).to eq(dn_out)
       end
     end
+
+    it "should support simple string transformation" do
+      dn_string = 'CN=Last First M (initial),O=rb,OU=people,C=us,DC=org,DC=example'
+      expect(DN.new(dn_string: dn_string, transformation: 'to_s').to_s).to eq(dn_string)
+    end
   end
 end

--- a/spec/lib/dn_spec.rb
+++ b/spec/lib/dn_spec.rb
@@ -89,5 +89,11 @@ describe DN do
       dn_string = 'CN=Last First M (initial),O=rb,OU=people,C=us,DC=org,DC=example'
       expect(DN.new(dn_string: dn_string, transformation: 'to_s').to_s).to eq(dn_string)
     end
+
+    it "should support different case cn" do
+      dn_string = 'cn=Last First M (initial),O=rb,OU=people,C=us,DC=org,DC=example'
+      dn_out = dn_string.gsub(/([^,]*)=/) { |i| i.upcase }
+      expect(DN.new(dn_string: dn_string, transformation: 'to_s').to_s).to eq(dn_out)
+    end
   end
 end

--- a/spec/lib/dn_spec.rb
+++ b/spec/lib/dn_spec.rb
@@ -95,5 +95,11 @@ describe DN do
       dn_out = dn_string.gsub(/([^,]*)=/) { |i| i.upcase }
       expect(DN.new(dn_string: dn_string, transformation: 'to_s').to_s).to eq(dn_out)
     end
+
+    it "should support not just idempotent transformation functions" do
+      dn_string = 'CN=Last First M (initial),O=rb,OU=people,C=us,DC=org,DC=example'
+      dn_out = dn_string.swapcase.gsub(/([^,]*)=/) { |i| i.upcase }
+      expect(DN.new(dn_string: dn_string, transformation: 'swapcase').to_s).to eq(dn_out)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+require "simplecov"
+SimpleCov.start
 
 require_relative '../lib/dnc'
 require 'awesome_print'


### PR DESCRIPTION
DNC tests always assume the upcase transformation function is in use. There are times this may not be wanted such as when using the CN for a nicely formated username for use in web app rather than it all be in shouty letters.

240c88d adds support for the to_s method when all attributes names in the original DN are in capital letters. Any array or hash attributes were previously broken as they used the downcase method name in the output. This fix makes hashes and arrays work the same as single strings from dn_string_to_string (attribute names **always** converted to upcase).

477b8b3 fixes an issue where if there is a downcase cn the validation would fail (even though it is valid as attribute name will be upcase due to the previous fix).

22142d1 fixes support for functions that produce a different result if run more than once. I assume the second transform in the to_s method was there as it was needed due to the downcase issue fixed by 240c88d. This extra transform is no longer required. swapcase is a simple test case as if it is run twice you end up with the original result which is not the desired outcome.
